### PR TITLE
ignore closed-issue-activity and closed-pr-activity labels

### DIFF
--- a/.github/workflows/issue-pr-tracker.yml
+++ b/.github/workflows/issue-pr-tracker.yml
@@ -63,7 +63,7 @@ jobs:
           echo 'Issue or PR [#${{ github.event.issue.number || github.event.pull_request.number }}](${{ github.event.issue.html_url || github.event.pull_request.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "Done"' >> $GITHUB_STEP_SUMMARY
       - name: Add Open PRs Without Review Requests
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.pull_request.requested_reviewers[0] == null && github.event.pull_request.requested_teams[0] == null && github.event.review.state != 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.pull_request.requested_reviewers[0] == null && github.event.pull_request.requested_teams[0] == null && github.event.review.state != 'approved' && ! contains(github.event.pull_request.labels.*.name, 'closed-pr-activity') }}
         with:
           gh_token: ${{ secrets.CR_PAT }}
           organization: linuxserver
@@ -71,12 +71,12 @@ jobs:
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: 'PRs'
       - name: Add Open PRs Without Review Requests (summary comment)
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.pull_request.requested_reviewers[0] == null && github.event.pull_request.requested_teams[0] == null && github.event.review.state != 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.pull_request.requested_reviewers[0] == null && github.event.pull_request.requested_teams[0] == null && github.event.review.state != 'approved' && ! contains(github.event.pull_request.labels.*.name, 'closed-pr-activity') }}
         run: |
           echo 'PR [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "PRs"' >> $GITHUB_STEP_SUMMARY
       - name: Add Open PRs With Review Requests
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && (github.event.pull_request.requested_reviewers[0] != null || github.event.pull_request.requested_teams[0] != null) && github.event.review.state != 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && (github.event.pull_request.requested_reviewers[0] != null || github.event.pull_request.requested_teams[0] != null) && github.event.review.state != 'approved' && ! contains(github.event.pull_request.labels.*.name, 'closed-pr-activity') }}
         with:
           gh_token: ${{ secrets.CR_PAT }}
           organization: linuxserver
@@ -84,12 +84,12 @@ jobs:
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: 'PRs Ready For Team Review'
       - name: Add Open PRs With Review Requests (summary comment)
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && (github.event.pull_request.requested_reviewers[0] != null || github.event.pull_request.requested_teams[0] != null) && github.event.review.state != 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && (github.event.pull_request.requested_reviewers[0] != null || github.event.pull_request.requested_teams[0] != null) && github.event.review.state != 'approved' && ! contains(github.event.pull_request.labels.*.name, 'closed-pr-activity') }}
         run: |
           echo 'PR [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "PRs Ready For Team Review"' >> $GITHUB_STEP_SUMMARY
       - name: Move Approved PRs
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.review.state == 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.review.state == 'approved' && ! contains(github.event.pull_request.labels.*.name, 'closed-pr-activity') }}
         with:
           gh_token: ${{ secrets.CR_PAT }}
           organization: linuxserver
@@ -97,7 +97,7 @@ jobs:
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: 'PRs Approved'
       - name: Move Approved PRs (summary comment)
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.review.state == 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.review.state == 'approved' && ! contains(github.event.pull_request.labels.*.name, 'closed-pr-activity') }}
         run: |
           echo 'PR [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "PRs Approved"' >> $GITHUB_STEP_SUMMARY
       - name: Add Comment on Invalid Labeling

--- a/.github/workflows/issue-pr-tracker.yml
+++ b/.github/workflows/issue-pr-tracker.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Add Open Docker Related Issues Not Labeled Invalid
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && startsWith(github.event.repository.name, 'docker-') && ! contains(github.event.issue.labels.*.name, 'invalid') }}
+        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && startsWith(github.event.repository.name, 'docker-') && ! contains(github.event.issue.labels.*.name, 'invalid') && ! contains(github.event.issue.labels.*.name, 'closed-issue-activity') }}
         with:
           gh_token: ${{ secrets.CR_PAT }}
           organization: linuxserver
@@ -19,12 +19,12 @@ jobs:
           resource_node_id: ${{ github.event.issue.node_id }}
           status_value: 'Issues'
       - name: Add Open Docker Related Issues Not Labeled Invalid (summary comment)
-        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && startsWith(github.event.repository.name, 'docker-') && ! contains(github.event.issue.labels.*.name, 'invalid') }}
+        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && startsWith(github.event.repository.name, 'docker-') && ! contains(github.event.issue.labels.*.name, 'invalid') && ! contains(github.event.issue.labels.*.name, 'closed-issue-activity') }}
         run: |
           echo 'Issue [#${{ github.event.issue.number }}](${{ github.event.issue.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "Issues"' >> $GITHUB_STEP_SUMMARY
       - name: Add Open Non-Docker Related Issues Not Labeled Invalid
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && ! startsWith(github.event.repository.name, 'docker-') && ! contains(github.event.issue.labels.*.name, 'invalid') }}
+        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && ! startsWith(github.event.repository.name, 'docker-') && ! contains(github.event.issue.labels.*.name, 'invalid') && ! contains(github.event.issue.labels.*.name, 'closed-issue-activity') }}
         with:
           gh_token: ${{ secrets.CR_PAT }}
           organization: linuxserver
@@ -32,12 +32,12 @@ jobs:
           resource_node_id: ${{ github.event.issue.node_id }}
           status_value: 'Non-Docker Issues'
       - name: Add Open Non-Docker Related Issues Not Labeled Invalid (summary comment)
-        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && ! startsWith(github.event.repository.name, 'docker-') && ! contains(github.event.issue.labels.*.name, 'invalid') }}
+        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && ! startsWith(github.event.repository.name, 'docker-') && ! contains(github.event.issue.labels.*.name, 'invalid') && ! contains(github.event.issue.labels.*.name, 'closed-issue-activity') }}
         run: |
           echo 'Issue [#${{ github.event.issue.number }}](${{ github.event.issue.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "Non-Docker Issues"' >> $GITHUB_STEP_SUMMARY
       - name: Add Open Issues Labeled Invalid
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && contains(github.event.issue.labels.*.name, 'invalid') }}
+        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && contains(github.event.issue.labels.*.name, 'invalid') && ! contains(github.event.issue.labels.*.name, 'closed-issue-activity') }}
         with:
           gh_token: ${{ secrets.CR_PAT }}
           organization: linuxserver
@@ -45,7 +45,7 @@ jobs:
           resource_node_id: ${{ github.event.issue.node_id }}
           status_value: 'Insufficient Info'
       - name: Add Open Issues Labeled Invalid (summary comment)
-        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && contains(github.event.issue.labels.*.name, 'invalid') }}
+        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && contains(github.event.issue.labels.*.name, 'invalid') && ! contains(github.event.issue.labels.*.name, 'closed-issue-activity') }}
         run: |
           echo 'Issue [#${{ github.event.issue.number }}](${{ github.event.issue.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "Insufficient Info"' >> $GITHUB_STEP_SUMMARY
       - name: Move Closed Issues and PRs to Done
@@ -63,7 +63,7 @@ jobs:
           echo 'Issue or PR [#${{ github.event.issue.number || github.event.pull_request.number }}](${{ github.event.issue.html_url || github.event.pull_request.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "Done"' >> $GITHUB_STEP_SUMMARY
       - name: Add Open PRs Without Review Requests
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.pull_request.requested_reviewers[0] == null && github.event.pull_request.requested_teams[0] == null && github.event.review.state != 'approved' }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.pull_request.requested_reviewers[0] == null && github.event.pull_request.requested_teams[0] == null && github.event.review.state != 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
         with:
           gh_token: ${{ secrets.CR_PAT }}
           organization: linuxserver
@@ -71,12 +71,12 @@ jobs:
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: 'PRs'
       - name: Add Open PRs Without Review Requests (summary comment)
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.pull_request.requested_reviewers[0] == null && github.event.pull_request.requested_teams[0] == null && github.event.review.state != 'approved' }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.pull_request.requested_reviewers[0] == null && github.event.pull_request.requested_teams[0] == null && github.event.review.state != 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
         run: |
           echo 'PR [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "PRs"' >> $GITHUB_STEP_SUMMARY
       - name: Add Open PRs With Review Requests
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && (github.event.pull_request.requested_reviewers[0] != null || github.event.pull_request.requested_teams[0] != null) && github.event.review.state != 'approved' }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && (github.event.pull_request.requested_reviewers[0] != null || github.event.pull_request.requested_teams[0] != null) && github.event.review.state != 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
         with:
           gh_token: ${{ secrets.CR_PAT }}
           organization: linuxserver
@@ -84,12 +84,12 @@ jobs:
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: 'PRs Ready For Team Review'
       - name: Add Open PRs With Review Requests (summary comment)
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && (github.event.pull_request.requested_reviewers[0] != null || github.event.pull_request.requested_teams[0] != null) && github.event.review.state != 'approved' }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && (github.event.pull_request.requested_reviewers[0] != null || github.event.pull_request.requested_teams[0] != null) && github.event.review.state != 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
         run: |
           echo 'PR [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "PRs Ready For Team Review"' >> $GITHUB_STEP_SUMMARY
       - name: Move Approved PRs
         uses: leonsteinhaeuser/project-beta-automations@v2.1.0
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.review.state == 'approved' }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.review.state == 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
         with:
           gh_token: ${{ secrets.CR_PAT }}
           organization: linuxserver
@@ -97,18 +97,18 @@ jobs:
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: 'PRs Approved'
       - name: Move Approved PRs (summary comment)
-        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.review.state == 'approved' }}
+        if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.owner.login == 'linuxserver') && github.event.pull_request.state == 'open' && github.event.review.state == 'approved' && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
         run: |
           echo 'PR [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }}) is added to [project](https://github.com/orgs/linuxserver/projects/8) column "PRs Approved"' >> $GITHUB_STEP_SUMMARY
       - name: Add Comment on Invalid Labeling
         uses: peter-evans/create-or-update-comment@v3.0.2
-        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && github.event.label.name == 'invalid' && contains(github.event.issue.labels.*.name, 'invalid') }}
+        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && github.event.label.name == 'invalid' && contains(github.event.issue.labels.*.name, 'invalid') && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
         with:
           issue-number: ${{ github.event.issue.number}}
           body: |
             A human has marked this issue as invalid, this likely happened because the issue template was not used in the creation of the issue.
       - name: Add Comment on Invalid Labeling (summary comment)
-        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && github.event.label.name == 'invalid' && contains(github.event.issue.labels.*.name, 'invalid') }}
+        if: ${{ github.event_name == 'issues' && github.event.issue.state == 'open' && github.event.label.name == 'invalid' && contains(github.event.issue.labels.*.name, 'invalid') && ! contains(github.event.issue.labels.*.name, 'closed-pr-activity') }}
         run: |
           echo 'Commented on issue [#${{ github.event.issue.number }}](${{ github.event.issue.html_url }}) that was marked invalid' >> $GITHUB_STEP_SUMMARY
       - name: Ignore Review Event On 3rd Party PRs


### PR DESCRIPTION
Hopefully will prevent the ace condition that occurs when the stale bot labels and closes an issue or pr in quick succession and the label action happens to run slightly slower than the close action like it happened here: https://github.com/linuxserver/docker-mods/issues/703#event-10137170913