### PR TITLE
use PAT for lock-threads

### DIFF
--- a/.github/workflows/issues-cron.yml
+++ b/.github/workflows/issues-cron.yml
@@ -75,3 +75,4 @@ jobs:
           include-any-pr-labels: no-pr-activity
           pr-comment: This pull request is locked due to inactivity
           exclude-any-pr-labels: awaiting-approval,work-in-progress
+          github-token: ${{ secrets.CR_PAT }}


### PR DESCRIPTION
We're getting a lot of workflow failures for the daily lock-threads action with the error message: `You have exceeded a secondary rate limit`

The action author recommends using a PAT as a workaround per https://github.com/dessant/lock-threads/issues/48#issuecomment-2072392969